### PR TITLE
package/protobuf3: fix Google-/GitHub-changed hash

### DIFF
--- a/package/protobuf3/protobuf3.hash
+++ b/package/protobuf3/protobuf3.hash
@@ -1,1 +1,1 @@
-sha256 0a0ae63cbffc274efb573bdde9a253e3f32e458c41261df51c5dbc5ad541e8f7  protobuf3-v3.1.0.tar.gz
+sha256 fb2a314f4be897491bb2446697be693d489af645cb0e165a85e7e64e07eb134d  protobuf3-v3.1.0.tar.gz


### PR DESCRIPTION
Based on other sites' hash updates, it looks like Google or GitHub did
indeed change the hash for this file, which lives at
https://github.com/google/protobuf/archive/v3.1.0.tar.gz .  So update
the local version accordingly to avoid "protobuf3-v3.1.0.tar.gz has
wrong sha256 hash" fatal error during the build process.