### PR TITLE
package/metis: MAKEFLAGS fix - no "target 'w'" err

### DIFF
--- a/package/metis/0001-Makefile-makeflags_done_right.patch
+++ b/package/metis/0001-Makefile-makeflags_done_right.patch
@@ -1,0 +1,11 @@
+--- metis-5.1.0.orig/Makefile
++++ metis-5.1.0.cs/Makefile
+@@ -64,7 +64,7 @@
+ 	@if [ ! -f $(BUILDDIR)/Makefile ]; then \
+ 		more BUILD.txt; \
+ 	else \
+-	  	make -C $(BUILDDIR) $@ $(MAKEFLAGS); \
++	  	make -C $(BUILDDIR) $@ MAKEFLAGS=$(MAKEFLAGS); \
+ 	fi
+ 
+ uninstall:


### PR DESCRIPTION
This patch fixes the "make[2]: *** No rule to make target 'w'.  Stop."
error; this is caused by MAKEFLAGS not being passed through correctly.